### PR TITLE
Switched back to the upstream ekscrypto Base64 library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .package(url: "https://github.com/tophatmonocle/Base64", .exact("1.2.0")),
+        .package(url: "https://github.com/ekscrypto/Base64", .exact("1.2.2")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Ekscrypto/Base64 now has SPM support so we no longer need our Base64 fork.